### PR TITLE
Add enable_go_template option for Go template rendering support

### DIFF
--- a/pkg/helmfile/release_set_unit_test.go
+++ b/pkg/helmfile/release_set_unit_test.go
@@ -1,0 +1,110 @@
+package helmfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGoTemplateFileExtension tests that the correct file extension is used
+// when enable_go_template is set to true or false
+func TestGoTemplateFileExtension(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name               string
+		enableGoTemplate   bool
+		expectedExtension  string
+	}{
+		{
+			name:              "Go template disabled - should use .yaml",
+			enableGoTemplate:  false,
+			expectedExtension: ".yaml",
+		},
+		{
+			name:              "Go template enabled - should use .yaml.gotmpl",
+			enableGoTemplate:  true,
+			expectedExtension: ".yaml.gotmpl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a ReleaseSet with test configuration
+			fs := &ReleaseSet{
+				Content:           "test: content",
+				WorkingDirectory:  tempDir,
+				Kubeconfig:        "/tmp/kubeconfig",
+				EnableGoTemplate:  tt.enableGoTemplate,
+				Bin:               "helmfile",  // Set binary name
+				HelmBin:           "helm",      // Set helm binary name
+			}
+
+			// Call NewCommandWithKubeconfig which sets the TmpHelmFilePath
+			_, err := NewCommandWithKubeconfig(fs, "version")
+			if err != nil {
+				t.Fatalf("NewCommandWithKubeconfig failed: %v", err)
+			}
+
+			// Check that the file extension is correct
+			if !strings.HasSuffix(fs.TmpHelmFilePath, tt.expectedExtension) {
+				t.Errorf("Expected file path to end with %q, but got %q",
+					tt.expectedExtension, fs.TmpHelmFilePath)
+			}
+
+			// Verify the file was actually created
+			fullPath := filepath.Join(tempDir, fs.TmpHelmFilePath)
+			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+				t.Errorf("Expected file %q to be created, but it doesn't exist", fullPath)
+			}
+
+			// Clean up the created file
+			os.Remove(fullPath)
+		})
+	}
+}
+
+// TestGoTemplateFileContent tests that the file content is written correctly
+// regardless of the template setting
+func TestGoTemplateFileContent(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testContent := `repositories:
+- name: stable
+  url: https://charts.helm.sh/stable
+
+releases:
+- name: myapp
+  chart: stable/nginx
+`
+
+	fs := &ReleaseSet{
+		Content:          testContent,
+		WorkingDirectory: tempDir,
+		Kubeconfig:       "/tmp/kubeconfig",
+		EnableGoTemplate: true,
+		Bin:              "helmfile",
+		HelmBin:          "helm",
+	}
+
+	_, err := NewCommandWithKubeconfig(fs, "version")
+	if err != nil {
+		t.Fatalf("NewCommandWithKubeconfig failed: %v", err)
+	}
+
+	// Read the created file and verify content
+	fullPath := filepath.Join(tempDir, fs.TmpHelmFilePath)
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		t.Fatalf("Failed to read created file: %v", err)
+	}
+
+	if string(content) != testContent {
+		t.Errorf("File content mismatch.\nExpected:\n%s\n\nGot:\n%s", testContent, string(content))
+	}
+
+	// Clean up
+	os.Remove(fullPath)
+}

--- a/pkg/helmfile/resource_release_set.go
+++ b/pkg/helmfile/resource_release_set.go
@@ -30,6 +30,7 @@ const KeyDirty = "dirty"
 const KeyConcurrency = "concurrency"
 const KeyReleasesValues = "releases_values"
 const KeySkipDiffOnMissingFiles = "skip_diff_on_missing_files"
+const KeyEnableGoTemplate = "enable_go_template"
 
 const HelmfileDefaultPath = "helmfile.yaml"
 
@@ -171,6 +172,12 @@ var ReleaseSetSchema = map[string]*schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		ForceNew: false,
+	},
+	KeyEnableGoTemplate: {
+		Type:     schema.TypeBool,
+		Optional: true,
+		ForceNew: false,
+		Default:  false,
 	},
 }
 


### PR DESCRIPTION
## Summary

This PR adds a new `enable_go_template` configuration option to `helmfile_release_set` that enables Go template rendering in helmfile by using the `.yaml.gotmpl` file extension.

## Motivation

Helmfile requires files to have a `.gotmpl` extension (or `.yaml.gotmpl`) to enable Go template processing. This is especially important for helmfile v0.150.0+ and the newer helmfile v1.x versions where the `.gotmpl` extension is required to enable templating features.

Without this option, users cannot utilize Go template features in their helmfile configurations when using this Terraform provider.

## Changes

- Added `enable_go_template` boolean field to the `helmfile_release_set` resource schema (defaults to `false` for backward compatibility)
- Added `EnableGoTemplate` field to `ReleaseSet` struct
- Modified file extension logic in `NewCommandWithKubeconfig` to use `.yaml.gotmpl` when enabled
- Added comprehensive unit tests to verify the feature works correctly

## Usage Example

```hcl
resource "helmfile_release_set" "mystack" {
  enable_go_template = true  # Enable Go template rendering
  
  content = file("./helmfile.yaml")
  kubeconfig = pathexpand("~/.kube/config")
  
  # ... other configuration
}
```

## Testing

Added unit tests that verify:
- ✅ Correct file extension (`.yaml.gotmpl`) is used when `enable_go_template = true`
- ✅ Default file extension (`.yaml`) is used when `enable_go_template = false`
- ✅ File content is preserved correctly
- ✅ All existing tests continue to pass

## Backward Compatibility

This change is fully backward compatible:
- The feature defaults to `false`, maintaining current behavior
- Existing configurations will continue to work without modification
- Only users who explicitly set `enable_go_template = true` will see the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)